### PR TITLE
Add support for Lando job IDs as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ cargo install --path .
 # Basic: get failed jobs as JSON
 treeherder-cli a13b9fc22101 --json
 
+# Use a Lando job ID instead of commit hash
+treeherder-cli --lando-job-id 12345 --json
+
+# Watch a Lando job until it lands, then monitor Treeherder jobs
+treeherder-cli --lando-job-id 12345 --watch --notify
+
 # Filter by job name or platform
 treeherder-cli a13b9fc22101 --filter "mochitest" --json
 treeherder-cli a13b9fc22101 --platform "linux.*64" --json

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -18,7 +18,10 @@ pub enum GroupBy {
     about = "Fetch and summarize Treeherder test results for Firefox developers"
 )]
 pub struct Args {
-    #[arg(help = "Treeherder URL or revision hash (not needed with --use-cache)")]
+    #[arg(
+        help = "Treeherder URL or revision hash (not needed with --use-cache)",
+        conflicts_with = "lando_job_id"
+    )]
     pub input: Option<String>,
     #[arg(long, default_value = "try", help = "Repository name")]
     pub repo: String,
@@ -103,4 +106,10 @@ pub struct Args {
         help = "Number of similar jobs to fetch for --similar-history"
     )]
     pub similar_count: usize,
+    #[arg(
+        long,
+        help = "Use a Lando job ID to fetch the commit hash (alternative to INPUT)",
+        conflicts_with = "input"
+    )]
+    pub lando_job_id: Option<u64>,
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -218,6 +218,13 @@ pub struct SimilarJobsMeta {
     pub repository: String,
 }
 
+#[derive(Deserialize, Debug)]
+pub struct LandoJobResponse {
+    pub id: u64,
+    pub status: String,
+    pub commit_id: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct SimilarJobHistory {
     pub job_id: u64,


### PR DESCRIPTION
Adds --lando-job-id flag to accept Lando job IDs instead of commit hashes. The tool queries api.lando.services.mozilla.com to fetch the commit hash for a given Lando job ID.

When combined with --watch, the tool also waits for the Lando job to land before proceeding to monitor Treeherder jobs.
This enables end-to-end workflow monitoring from code landing to CI completion.